### PR TITLE
added user error helper method

### DIFF
--- a/ib
+++ b/ib
@@ -18,6 +18,11 @@ import argparse, ast, os, platform, subprocess, tempfile, textwrap
 class IbError(Exception): pass
 
 
+def RaiseNiceley(exception, message):
+  print "\n".join([" ", message, " "])
+  raise exception
+
+
 def GetExt(path):
   _, ext = os.path.splitext(path)
   return ext
@@ -508,7 +513,15 @@ class Planner(object):
     hdrs = self.cached_hdrs.get(abspath)
     if hdrs is None:
       args = self.GetCcArgs() + self.cfg.cc.hdrs_flags + [ abspath ]
-      output = subprocess.check_output(args)
+      output = None
+
+      try:
+        output = subprocess.check_output(args)
+      except OSError as err:
+        RaiseNiceley(
+          err,
+          "OS returned error while executing `" + " ".join(self.GetCcArgs()) + "`")
+
       output = output.split(':', 1)[1]
       output = output.replace('\\', ' ')
       hdrs = []

--- a/ib
+++ b/ib
@@ -261,9 +261,9 @@ class LinkerJob(Job):
         [ '-o ' + rule.outputs[0] ] + list(rule.dependencies) +
         [ '-L' + lib_dir for lib_dir in planner.cfg.link.lib_dirs ] +
         [ '-l' + lib for lib in planner.cfg.link.libs ] +
-        [ '-Wl,-Bstatic' ] +
+        ([ '-Wl,-Bstatic' ] if platform.system() != 'Darwin' else []) +
         [ '-l' + lib for lib in planner.cfg.link.static_libs ] +
-        [ '-Wl,-Bdynamic' ])
+        ([ '-Wl,-Bdynamic' ] if platform.system() != 'Darwin' else []))
     return rule
 
   VERB = 'link'


### PR DESCRIPTION
This pr enables a nice message if user doesn't have the correct compiler installed, or the command simply fails. The functionality remains the same since OSError is still being thrown in `RaiseNicely`. It's much easier to understand what is going wrong when the user knows what command fails.

```
OS returned error while executing `clang-3.5 -I/Users/dhoodlum/src/ib -I/Users/dhoodlum/src/out/debug -DIB_SRC_ROOT=/Users/dhoodlum/src/ib -DIB_OUT_ROOT=/Users/dhoodlum/src/out/debug --std=c++14 -Weverything -Wno-c++98-compat -Wno-shadow -Wno-global-constructors -Wno-exit-time-destructors -Wno-padded -Wno-weak-vtables -g -DDJ_ENABLE_ABORT_IF -Wno-unused-private-field`

Traceback (most recent call last):
  File "/Users/dhoodlum/src/ib/ib", line 887, in <module>
    exit(main())
  File "/Users/dhoodlum/src/ib/ib", line 854, in main
    for wave_number, wave in enumerate(planner.YieldWaves(specs), start=1):
  File "/Users/dhoodlum/src/ib/ib", line 607, in YieldWaves
    for implied_spec in plan.YieldImpliedSpecs(self):
  File "/Users/dhoodlum/src/ib/ib", line 349, in YieldImpliedSpecs
    for implied_spec in self.output_spec.YieldImpliedSpecs(planner, self.GetOutputAbspath(planner)):
  File "/Users/dhoodlum/src/ib/ib", line 113, in YieldImpliedSpecs
    for hdr in planner.GetHdrs(abspath):
  File "/Users/dhoodlum/src/ib/ib", line 523, in GetHdrs
    "OS returned error while executing `" + " ".join(self.GetCcArgs()) + "`")
  File "/Users/dhoodlum/src/ib/ib", line 23, in RaiseNiceley
    raise exception
OSError: [Errno 2] No such file or directory
```