### PR TITLE
Use cross platform shebang in ib executable

### DIFF
--- a/ib
+++ b/ib
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright Jason Lucas
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
My python executable is not located in /usr/bin/python because I use python3 for /usr/bin/python